### PR TITLE
chore: update test matrix to 16.x and 18.x

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -16,7 +16,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [12.x, 14.x]
+        node-version: [16.x, 18.x]
 
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
BREAKING CHANGE: drop support for Node.js 12.x